### PR TITLE
Create N bit hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ If no correct submission has been submitted within one month, we _may_ increasin
 
 ## Additional hints
 
-We may offer additional hints at some point in August or September. The hints will most likely be initial bits of a fast hash of the solutions. The nature of the hints is under discussion in [this forum topic](https://discussions.agilebits.com/discussion/89318/world-password-day-cracking-challenge/p1).
+We may offer additional hints at some point in August or September.
+The hints will be initial bit(s) of a SHA256 unsalted hash of the password.
+The nature of the hints has been under discussion in [this forum topic](https://discussions.agilebits.com/discussion/89318/world-password-day-cracking-challenge/p1).
 
 ## Rules
 
@@ -96,9 +98,9 @@ Last update: <!-- date -u "+%Y-%m-%d:%H:%M:%S UTC" --> 2018-05-03:20:33:44 UTC
 
 ID         |  Status   |  Successful password      | Hint | Submission date | By whom       | Place | Write-up location
 :----------|-----------|:--------------------------|:-----|-----------------|:--------------|-------|:-----------------
-3UOKUEBO   | Sample    | governor washout beak     |      | N/A             | Sample        | 0th   | N/A
-AJPYJUTN   | Sample    | glassy ubiquity absence   |      | N/A             | Sample        | 0th   | N/A
-IV2DL67Q   | Sample    | splendor excel rarefy     |      | N/A             | Sample        | 0th   | N/A
+3UOKUEBO   | Sample    | governor washout beak     | 0b0  | N/A             | Sample        | 0th   | N/A
+AJPYJUTN   | Sample    | glassy ubiquity absence   | 0b1  | N/A             | Sample        | 0th   | N/A
+IV2DL67Q   | Sample    | splendor excel rarefy     | 0b0  | N/A             | Sample        | 0th   | N/A
 NO4VRU4S   | Not found |                           |      |                 |               | Nth   |
 33YRS77A   | Not found |                           |      |                 |               | Nth   |
 J6J4QUWQ   | Not found |                           |      |                 |               | Nth   |

--- a/cmd/chcreator/main.go
+++ b/cmd/chcreator/main.go
@@ -15,6 +15,7 @@ import (
 
 var withPwds = flag.Bool("p", false, "Output should contain all passwords")
 var testKeys = flag.Bool("t", false, "Test whether input derived keys match calculated")
+var hintBits = flag.Int("b", 0, "bits of hint to be offered")
 
 func main() {
 	flag.Parse()
@@ -26,7 +27,7 @@ func main() {
 	challenges := getChallenges()
 
 	for _, c := range challenges {
-		c.FleshOut()
+		c.FleshOut(*hintBits)
 
 		if *testKeys {
 			if c.Dk != nil {

--- a/cmd/chcreator/main.go
+++ b/cmd/chcreator/main.go
@@ -1,3 +1,4 @@
+// +build debug
 package main
 
 import (
@@ -17,7 +18,6 @@ var withPwds = flag.Bool("p", false, "Output should contain all passwords")
 var testKeys = flag.Bool("t", false, "Test whether input derived keys match calculated")
 var hintBits = flag.Int("b", 0, "bits of hint to be offered")
 var fileFlag = flag.String("f", "", "input file name")
-var bFlag = uint8(*hintBits)
 
 func main() {
 	flag.Parse()
@@ -58,10 +58,12 @@ func main() {
 		}
 	}
 
-	if bFlag > 0 {
+	log.Printf("bFlag is %d\n", *hintBits)
+	if *hintBits > 0 {
 		for _, c := range challenges {
 			if c.Pwd != "" {
-				c.BitHint = crackme.MakeBitHint(c.Pwd, bFlag)
+				c.BitHint = crackme.MakeBitHint(c.Pwd, *hintBits)
+				log.Printf("%s: %s\n", c.ID, c.BitHint)
 			}
 		}
 	}

--- a/cmd/chcreator/main.go
+++ b/cmd/chcreator/main.go
@@ -58,12 +58,10 @@ func main() {
 		}
 	}
 
-	log.Printf("bFlag is %d\n", *hintBits)
 	if *hintBits > 0 {
 		for _, c := range challenges {
 			if c.Pwd != "" {
 				c.BitHint = crackme.MakeBitHint(c.Pwd, *hintBits)
-				log.Printf("%s: %s\n", c.ID, c.BitHint)
 			}
 		}
 	}

--- a/crackme.go
+++ b/crackme.go
@@ -74,7 +74,7 @@ func (c *Challenge) DeriveKey() ([]byte, error) {
 
 // FleshOut takes what exists within a challenge and fills in defaults and other
 // fields based on what is there.
-func (c *Challenge) FleshOut(bits uint8) {
+func (c *Challenge) FleshOut() {
 	if c.Rounds == 0 {
 		c.Rounds = DefaultRounds
 	}
@@ -110,13 +110,11 @@ func (c *Challenge) FleshOut(bits uint8) {
 		// By taking a multiple of five bytes, we get base32 encoding without padding
 		c.ID = MakeID(c.Salt)
 	}
-	if bits != 0 {
-		c.BitHint = makeBitHint(c.Pwd, bits)
-	}
-
 }
 
-func makeBitHint(s string, bits uint8) string {
+// MakeBitHint returns a string representing the first bits bits of the
+// SHA256 hash of the string
+func MakeBitHint(s string, bits uint8) string {
 	if bits < 1 {
 		return "0b"
 	}

--- a/crackme.go
+++ b/crackme.go
@@ -74,7 +74,7 @@ func (c *Challenge) DeriveKey() ([]byte, error) {
 
 // FleshOut takes what exists within a challenge and fills in defaults and other
 // fields based on what is there.
-func (c *Challenge) FleshOut(bits int) {
+func (c *Challenge) FleshOut(bits uint8) {
 	if c.Rounds == 0 {
 		c.Rounds = DefaultRounds
 	}
@@ -111,12 +111,12 @@ func (c *Challenge) FleshOut(bits int) {
 		c.ID = MakeID(c.Salt)
 	}
 	if bits != 0 {
-		c.BitHint = c.makeBitHint(bits)
+		c.BitHint = makeBitHint(c.Pwd, bits)
 	}
 
 }
 
-func (c Challenge) makeBitHint(bits int) string {
+func makeBitHint(s string, bits uint8) string {
 	if bits < 1 {
 		return "0b"
 	}
@@ -124,13 +124,16 @@ func (c Challenge) makeBitHint(bits int) string {
 		bits = 8
 	}
 	h := sha256.New()
-	h.Write([]byte(c.Pwd))
+	h.Write([]byte(s))
 	lead := h.Sum(nil)[0]
 
 	// will right shift lead by 8 - bits
+	lead >>= 8 - bits
 
 	// then print result to bits places
-
+	fmtString := fmt.Sprintf("0b%%0%db", bits)
+	out := fmt.Sprintf(fmtString, lead)
+	return out
 }
 
 func (c *Challenge) String() string {

--- a/crackme.go
+++ b/crackme.go
@@ -28,6 +28,7 @@ type Challenge struct {
 	SaltHex  string `json:"salt"`
 	DkHex    string `json:"derived,omitempty"`
 	Pwd      string `json:"pwd,omitempty"`
+	BitHint  string `json:"bitHint,omitempty"`
 
 	KeyLen  int    `json:"-"`
 	Salt    []byte `json:"-"`
@@ -73,7 +74,7 @@ func (c *Challenge) DeriveKey() ([]byte, error) {
 
 // FleshOut takes what exists within a challenge and fills in defaults and other
 // fields based on what is there.
-func (c *Challenge) FleshOut() {
+func (c *Challenge) FleshOut(bits int) {
 	if c.Rounds == 0 {
 		c.Rounds = DefaultRounds
 	}
@@ -109,6 +110,27 @@ func (c *Challenge) FleshOut() {
 		// By taking a multiple of five bytes, we get base32 encoding without padding
 		c.ID = MakeID(c.Salt)
 	}
+	if bits != 0 {
+		c.BitHint = c.makeBitHint(bits)
+	}
+
+}
+
+func (c Challenge) makeBitHint(bits int) string {
+	if bits < 1 {
+		return "0b"
+	}
+	if bits > 8 {
+		bits = 8
+	}
+	h := sha256.New()
+	h.Write([]byte(c.Pwd))
+	lead := h.Sum(nil)[0]
+
+	// will right shift lead by 8 - bits
+
+	// then print result to bits places
+
 }
 
 func (c *Challenge) String() string {

--- a/crackme.go
+++ b/crackme.go
@@ -114,7 +114,7 @@ func (c *Challenge) FleshOut() {
 
 // MakeBitHint returns a string representing the first bits bits of the
 // SHA256 hash of the string
-func MakeBitHint(s string, bits uint8) string {
+func MakeBitHint(s string, bits int) string {
 	if bits < 1 {
 		return "0b"
 	}
@@ -126,7 +126,7 @@ func MakeBitHint(s string, bits uint8) string {
 	lead := h.Sum(nil)[0]
 
 	// will right shift lead by 8 - bits
-	lead >>= 8 - bits
+	lead >>= 8 - uint(bits)
 
 	// then print result to bits places
 	fmtString := fmt.Sprintf("0b%%0%db", bits)

--- a/crackme_test.go
+++ b/crackme_test.go
@@ -56,7 +56,7 @@ func (tvec TestVector) String() string {
 func TestBitHint(t *testing.T) {
 	type vec struct {
 		in       string
-		bits     uint8
+		bits     int
 		expected string
 	}
 
@@ -64,7 +64,7 @@ func TestBitHint(t *testing.T) {
 
 	Using
 
-		for p in one two three four; do
+		for p in one two three four "governor washout beak" "glassy ubiquity absence" "splendor excel rarefy"; do
 			h=$(echo -n $p | shasum -a256 | cut -b1-2)
 			echo "$p:  $h"
 		done
@@ -82,18 +82,32 @@ func TestBitHint(t *testing.T) {
 		{"two", 1, "0b0"},
 		{"three", 1, "0b1"},
 		{"four", 1, "0b0"},
+
 		{"one", 2, "0b01"},
 		{"two", 2, "0b00"},
 		{"three", 2, "0b10"},
 		{"four", 2, "0b00"},
+
 		{"one", 3, "0b011"},
 		{"two", 3, "0b001"},
 		{"three", 3, "0b100"},
 		{"four", 3, "0b000"},
+
+		{"governor washout beak", 1, "0b0"},
+		{"glassy ubiquity absence", 1, "0b1"},
+		{"splendor excel rarefy", 1, "0b0"},
+
+		{"governor washout beak", 2, "0b01"},
+		{"glassy ubiquity absence", 2, "0b11"},
+		{"splendor excel rarefy", 2, "0b01"},
+
+		{"governor washout beak", 3, "0b011"},
+		{"glassy ubiquity absence", 3, "0b111"},
+		{"splendor excel rarefy", 3, "0b010"},
 	}
 
 	for _, v := range vecs {
-		result := makeBitHint(v.in, v.bits)
+		result := MakeBitHint(v.in, v.bits)
 		if result != v.expected {
 			t.Errorf("For s = %q expected %q but got %q", v.in, v.expected, result)
 		}

--- a/crackme_test.go
+++ b/crackme_test.go
@@ -52,3 +52,51 @@ func (tvec TestVector) String() string {
 
 	return r
 }
+
+func TestBitHint(t *testing.T) {
+	type vec struct {
+		in       string
+		bits     uint8
+		expected string
+	}
+
+	/* For tests I need the first byte of the sha256 hash of some strings
+
+	Using
+
+		for p in one two three four; do
+			h=$(echo -n $p | shasum -a256 | cut -b1-2)
+			echo "$p:  $h"
+		done
+
+	I got
+
+		one:  76
+		two:  3f
+		three:  8b
+		four:  04
+	*/
+
+	vecs := []vec{
+		{"one", 1, "0b0"},
+		{"two", 1, "0b0"},
+		{"three", 1, "0b1"},
+		{"four", 1, "0b0"},
+		{"one", 2, "0b01"},
+		{"two", 2, "0b00"},
+		{"three", 2, "0b10"},
+		{"four", 2, "0b00"},
+		{"one", 3, "0b011"},
+		{"two", 3, "0b001"},
+		{"three", 3, "0b100"},
+		{"four", 3, "0b000"},
+	}
+
+	for _, v := range vecs {
+		result := makeBitHint(v.in, v.bits)
+		if result != v.expected {
+			t.Errorf("For s = %q expected %q but got %q", v.in, v.expected, result)
+		}
+	}
+
+}


### PR DESCRIPTION
This adds the command-line option `-b N`, which will generate an _N_-bit hint in the output. The hint is the first _N_ bits of the unsalted SHA256 hash of the password.

This PR also adds a -f filename option to specify an input file other than standard input. This was because I couldn't figure out how to redirect standard input while running the debugger.

This all would have been much simpler if I had been able to get the debugger working. A simple int casting issue took way too much time to identify.